### PR TITLE
Callback Url Configuration. Resolve API reorganize.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 db-data
 .DS_Store
 *.lock
+.vscode

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,27 +13,14 @@ services:
       interval: 30s
       timeout: 10s
       retries: 4
-  db:
-    image: postgres
-    volumes:
-      - ./${DB_DIR-db-data}:/var/lib/postgresql/data
-    environment:
-      - POSTGRES_DB=registry
-      - POSTGRES_USER=postgres
-      - POSTGRES_PASSWORD=postgres
-    healthcheck:
-      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
-      interval: 10s
-      timeout: 5s
-      retries: 5
   registry:
     image: tejashjl/sunbird-rc-core:v0.0.13-7
     volumes:
       - ${PWD}/${SCHEMA_DIR-schemas}:/home/sunbirdrc/config/public/_schemas
     environment:
-      - connectionInfo_uri=jdbc:postgresql://db:5432/registry
-      - connectionInfo_username=postgres
-      - connectionInfo_password=postgres
+      - connectionInfo_uri=jdbc:postgresql://172.17.0.1:5432/sunbirdmapperdb
+      - connectionInfo_username=sunbirduser
+      - connectionInfo_password=1234
       - elastic_search_connection_url=es:9200
       - elastic_search_auth_enabled=${ELASTIC_SECURITY_ENABLED-false}
       - elastic_search_username=${ELASTIC_SEARCH_USERNAME-elastic}
@@ -48,8 +35,6 @@ services:
     depends_on:
       es:
         condition: service_healthy
-      db:
-        condition: service_healthy
     healthcheck:
       test: [ "CMD-SHELL", "wget -nv -t1 --spider http://localhost:8081/health || exit 1" ]
       interval: 30s
@@ -60,7 +45,7 @@ services:
     volumes:
       - ${PWD}/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
     ports:
-      - "80:80"
+      - "8087:80"
     depends_on:
       registry:
         condition: service_healthy
@@ -74,6 +59,8 @@ services:
     environment:
       - REGISTRY_URL=http://registry:8081/
       - CALLBACK_SERVICE_URL=http://callback-service:8765/v0.1.0/mapper/
+    ports:
+      - "8766:8766"
   callback-service:
     build: services/callback-service
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,14 +13,27 @@ services:
       interval: 30s
       timeout: 10s
       retries: 4
+  db:
+    image: postgres
+    volumes:
+      - ./${DB_DIR-db-data}:/var/lib/postgresql/data
+    environment:
+      - POSTGRES_DB=registry
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+    healthcheck:
+      test: [ "CMD-SHELL", "pg_isready -U postgres" ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
   registry:
     image: tejashjl/sunbird-rc-core:v0.0.13-7
     volumes:
       - ${PWD}/${SCHEMA_DIR-schemas}:/home/sunbirdrc/config/public/_schemas
     environment:
-      - connectionInfo_uri=jdbc:postgresql://172.17.0.1:5432/sunbirdmapperdb
-      - connectionInfo_username=sunbirduser
-      - connectionInfo_password=1234
+      - connectionInfo_uri=jdbc:postgresql://db:5432/registry
+      - connectionInfo_username=postgres
+      - connectionInfo_password=postgres
       - elastic_search_connection_url=es:9200
       - elastic_search_auth_enabled=${ELASTIC_SECURITY_ENABLED-false}
       - elastic_search_username=${ELASTIC_SEARCH_USERNAME-elastic}
@@ -42,6 +55,8 @@ services:
     depends_on:
       es:
         condition: service_healthy
+      db:
+        condition: service_healthy
     healthcheck:
       test: [ "CMD-SHELL", "wget -nv -t1 --spider http://localhost:8081/health || exit 1" ]
       interval: 30s
@@ -52,7 +67,7 @@ services:
     volumes:
       - ${PWD}/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
     ports:
-      - "8087:80"
+      - "80:80"
     depends_on:
       registry:
         condition: service_healthy
@@ -66,10 +81,6 @@ services:
     environment:
       - REGISTRY_URL=http://registry:8081/
       - CALLBACK_SERVICE_URL=http://callback-service:8765/v0.1.0/mapper/
-      - SWAGGER_DEBUG="1"
-      - DEBUG="1"
-    ports:
-      - "8766:8766"
   callback-service:
     build: services/callback-service
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,8 @@ services:
     environment:
       - REGISTRY_URL=http://registry:8081/
       - CALLBACK_SERVICE_URL=http://callback-service:8765/v0.1.0/mapper/
+      - SWAGGER_DEBUG="1"
+      - DEBUG="1"
     ports:
       - "8766:8766"
   callback-service:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,13 @@ services:
       - webhook_enabled=false
       - webhook_url=http://localhost:5001/api/v1/callback
       - manager_type=${MANAGER_TYPE-DefinitionsManager}
+      - claims_enabled=${CLAIMS_ENABLED-false}
+      - signature_enabled=${CLAIMS_ENABLED-false}
+      - certificate_enabled=${CERTIFICATE_ENABLED-false}
+      - filestorage_enabled=${FILESSTORAGE_ENABLED-false}
+      - async_enabled=${ASYNC_ENABLED-false}
+      - notification_async_enabled=${NOTIFICATION_ASYNC_ENABLED-false}
+      - notification_enabled=${NOTIFICATION_ENABLED-false}
     depends_on:
       es:
         condition: service_healthy

--- a/mapper-ui/src/config.js
+++ b/mapper-ui/src/config.js
@@ -1,3 +1,3 @@
 export const config = {
-    BASE_URL: "http://localhost:8087"
+    BASE_URL: "https://g2p-financial-wrapper.sunbirdrc.dev"
 }

--- a/mapper-ui/src/config.js
+++ b/mapper-ui/src/config.js
@@ -1,3 +1,3 @@
 export const config = {
-    BASE_URL: "https://g2p-financial-wrapper.sunbirdrc.dev"
+    BASE_URL: "http://localhost:8087"
 }

--- a/mapper-ui/src/util.js
+++ b/mapper-ui/src/util.js
@@ -9,7 +9,7 @@ export function createMapperHeader(mode) {
         "message_ts": new Date().toISOString(),
         "action": mode,
         "sender_id": "mapper.sunbirdrc.dev",
-        "sender_uri": config.BASE_URL,
+        "sender_uri": "",
         "receiver_id": "callback.sunbirdrc.dev",
         "total_count": 0,
         "is_encrypted": false

--- a/services/mapper-service/api/handlers/link.go
+++ b/services/mapper-service/api/handlers/link.go
@@ -1,12 +1,13 @@
 package handlers
 
 import (
+	"strings"
+	"time"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sunbirdrc/mapper-service/services"
 	"github.com/sunbirdrc/mapper-service/swagger_gen/models"
 	"github.com/sunbirdrc/mapper-service/swagger_gen/restapi/operations"
-	"strings"
-	"time"
 )
 
 const SUCCESS = "succ"

--- a/services/mapper-service/api/handlers/link.go
+++ b/services/mapper-service/api/handlers/link.go
@@ -42,7 +42,7 @@ func (l link) Handle(params operations.PostG2pMapperLinkParams) middleware.Respo
 	}
 
 	onLinkRequest := l.createOnLinkRequestPayload(params, linkResponses)
-	services.NewCallbackService().Callback(onLinkRequest, "on-link")
+	services.NewCallbackService(string(params.Body.Header.SenderURI)).Callback(onLinkRequest, "on-link")
 
 	response := operations.NewPostG2pMapperLinkDefault(200)
 	response.Payload = &operations.PostG2pMapperLinkDefaultBody{

--- a/services/mapper-service/api/handlers/resolve.go
+++ b/services/mapper-service/api/handlers/resolve.go
@@ -85,7 +85,7 @@ func (u resolve) createResolveResponse(resolveRequest *models.ResolveRequest, re
 	}
 	if len(resolveEntityResponse) <= 0 {
 		resolveResponse.Status = models.NewRequestStatus(FAILURE)
-		resolveResponse.StatusReasonCode = "rjct.id.invalid"
+		resolveResponse.StatusReasonCode = "rjct.reference_id.invalid"
 		resolveResponse.StatusReasonMessage = "ID is invalid or not found."
 	} else {
 		resolveResponse.ID = models.PersonID(resolveEntityResponse[0].Id)

--- a/services/mapper-service/api/handlers/resolve.go
+++ b/services/mapper-service/api/handlers/resolve.go
@@ -38,7 +38,7 @@ func (u resolve) Handle(params operations.PostG2pMapperResolveParams) middleware
 	}
 
 	onUpdateRequest := u.createOnResolveRequestPayload(params, resolveResponses)
-	services.NewCallbackService().Callback(onUpdateRequest, "on-resolve")
+	services.NewCallbackService(string(params.Body.Header.SenderURI)).Callback(onUpdateRequest, "on-resolve")
 
 	response := operations.NewPostG2pMapperResolveDefault(200)
 	response.Payload = &operations.PostG2pMapperResolveDefaultBody{

--- a/services/mapper-service/api/handlers/search.go
+++ b/services/mapper-service/api/handlers/search.go
@@ -1,11 +1,12 @@
 package handlers
 
 import (
+	"time"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sunbirdrc/mapper-service/services"
 	"github.com/sunbirdrc/mapper-service/swagger_gen/models"
 	"github.com/sunbirdrc/mapper-service/swagger_gen/restapi/operations"
-	"time"
 )
 
 // SearchHandler handles a request for linking an entry

--- a/services/mapper-service/api/handlers/search.go
+++ b/services/mapper-service/api/handlers/search.go
@@ -44,7 +44,7 @@ func (u search) Handle(params operations.PostG2pFamapSearchParams) middleware.Re
 	}
 
 	onUpdateRequest := u.createOnSearchRequestPayload(params, searchResponses)
-	services.NewCallbackService().Callback(onUpdateRequest, "on-search")
+	services.NewCallbackService(string(params.Body.Header.SenderURI)).Callback(onUpdateRequest, "on-search")
 
 	response := operations.NewPostG2pFamapSearchDefault(200)
 	response.Payload = &operations.PostG2pFamapSearchDefaultBody{

--- a/services/mapper-service/api/handlers/unlink.go
+++ b/services/mapper-service/api/handlers/unlink.go
@@ -45,7 +45,7 @@ func (u unlink) Handle(params operations.PostG2pMapperUnlinkParams) middleware.R
 	}
 
 	onUpdateRequest := u.createOnUnlinkRequestPayload(params, unlinkResponses)
-	services.NewCallbackService().Callback(onUpdateRequest, "on-unlink")
+	services.NewCallbackService(string(params.Body.Header.SenderURI)).Callback(onUpdateRequest, "on-unlink")
 
 	response := operations.NewPostG2pMapperUnlinkDefault(200)
 	response.Payload = &operations.PostG2pMapperUnlinkDefaultBody{

--- a/services/mapper-service/api/handlers/unlink.go
+++ b/services/mapper-service/api/handlers/unlink.go
@@ -1,12 +1,13 @@
 package handlers
 
 import (
+	"strings"
+	"time"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sunbirdrc/mapper-service/services"
 	"github.com/sunbirdrc/mapper-service/swagger_gen/models"
 	"github.com/sunbirdrc/mapper-service/swagger_gen/restapi/operations"
-	"strings"
-	"time"
 )
 
 // UnlinkHandler handles a request for linking an entry

--- a/services/mapper-service/api/handlers/update.go
+++ b/services/mapper-service/api/handlers/update.go
@@ -46,7 +46,7 @@ func (u update) Handle(params operations.PutG2pMapperUpdateParams) middleware.Re
 	}
 
 	onUpdateRequest := u.createOnUpdateRequestPayload(params, updateResponses)
-	services.NewCallbackService().Callback(onUpdateRequest, "on-update")
+	services.NewCallbackService(string(params.Body.Header.SenderURI)).Callback(onUpdateRequest, "on-update")
 
 	response := operations.NewPutG2pMapperUpdateDefault(200)
 	response.Payload = &operations.PutG2pMapperUpdateDefaultBody{

--- a/services/mapper-service/api/handlers/update.go
+++ b/services/mapper-service/api/handlers/update.go
@@ -1,12 +1,13 @@
 package handlers
 
 import (
+	"strings"
+	"time"
+
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/sunbirdrc/mapper-service/services"
 	"github.com/sunbirdrc/mapper-service/swagger_gen/models"
 	"github.com/sunbirdrc/mapper-service/swagger_gen/restapi/operations"
-	"strings"
-	"time"
 )
 
 // UpdateHandler handles a request for linking an entry

--- a/services/mapper-service/services/callback_service.go
+++ b/services/mapper-service/services/callback_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+
 	"github.com/imroc/req/v3"
 	log "github.com/sirupsen/logrus"
 	"github.com/sunbirdrc/mapper-service/config"

--- a/services/mapper-service/services/callback_service.go
+++ b/services/mapper-service/services/callback_service.go
@@ -8,8 +8,6 @@ import (
 	"github.com/sunbirdrc/mapper-service/config"
 )
 
-var service = CallbackService{}
-
 func NewCallbackService(callbackUrl string) CallbackService {
 	var url string
 	if callbackUrl != "" {
@@ -17,25 +15,22 @@ func NewCallbackService(callbackUrl string) CallbackService {
 	} else {
 		url = config.Config.CallbackService.Url
 	}
-	if service.Client == nil {
-		c := req.C().
-			// All GitHub API requests need this header.
-			DevMode().
-			SetCommonHeader("Accept", "application/json").
-			// All GitHub API requests use the same base URL.
-			SetBaseURL(url).
-			// Enable dump at the request-level for each request, and only
-			// temporarily stores the dump content in memory, so we can call
-			// resp.Dump() to get the dump content when needed in response
-			// middleware.
-			// This is actually a syntax sugar, implemented internally using
-			// request middleware
-			EnableDumpEachRequest()
-		service = CallbackService{
-			Client: c,
-		}
+	c := req.C().
+		// All GitHub API requests need this header.
+		DevMode().
+		SetCommonHeader("Accept", "application/json").
+		// All GitHub API requests use the same base URL.
+		SetBaseURL(url).
+		// Enable dump at the request-level for each request, and only
+		// temporarily stores the dump content in memory, so we can call
+		// resp.Dump() to get the dump content when needed in response
+		// middleware.
+		// This is actually a syntax sugar, implemented internally using
+		// request middleware
+		EnableDumpEachRequest()
+	return CallbackService{
+		Client: c,
 	}
-	return service
 }
 
 type CallbackService struct {

--- a/services/mapper-service/services/callback_service.go
+++ b/services/mapper-service/services/callback_service.go
@@ -10,14 +10,20 @@ import (
 
 var service = CallbackService{}
 
-func NewCallbackService() CallbackService {
+func NewCallbackService(callbackUrl string) CallbackService {
+	var url string
+	if callbackUrl != "" {
+		url = callbackUrl
+	} else {
+		url = config.Config.CallbackService.Url
+	}
 	if service.Client == nil {
 		c := req.C().
 			// All GitHub API requests need this header.
 			DevMode().
 			SetCommonHeader("Accept", "application/json").
 			// All GitHub API requests use the same base URL.
-			SetBaseURL(config.Config.CallbackService.Url).
+			SetBaseURL(url).
 			// Enable dump at the request-level for each request, and only
 			// temporarily stores the dump content in memory, so we can call
 			// resp.Dump() to get the dump content when needed in response

--- a/services/mapper-service/services/registry.go
+++ b/services/mapper-service/services/registry.go
@@ -2,11 +2,12 @@ package services
 
 import (
 	"fmt"
+	"reflect"
+
 	"github.com/imroc/req/v3"
 	log "github.com/sirupsen/logrus"
 	"github.com/sunbirdrc/mapper-service/config"
 	"github.com/sunbirdrc/mapper-service/swagger_gen/models"
-	"reflect"
 )
 
 const FinancialAddressMapper = "FinancialAddressMapper"


### PR DESCRIPTION
This PR includes the following.
- Currently, the URL for calling back with any API response(resolve, update, delete, search) is preconfigured on the mapper service (callback service url). This PR modifies that.
  - If a sender uri is provided in the request header, it will use that as the callback URL.
  - Else it will continue to use the configured callback service url.
- Changed the internal behavior of resolve API.
  - Right now it will call GetEntity with the given ID, i.e., uses the registry search API to search for ID and returns back the first result if found (similar to mapper search API).
  - Else if not found, it returns error.
  - Without these changes, the mapper resolve API was always responding with a static success message, against any given id.